### PR TITLE
Add support for dart closing labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Repo to hold a bunch of info &amp; extension callbacks for built-in LSP. Use at 
 Requires Built-in LSP, [Neovim Nightly](https://github.com/neovim/neovim/releases/tag/nightly), [nvim-lsp](https://github.com/neovim/nvim-lsp)
 
 ```vimscript
-" LSP Extensions (inlay-hints)
+" LSP Extensions
 Plug 'tjdevries/lsp_extensions.nvim'
 ```
 
@@ -56,6 +56,13 @@ require'lsp_extensions'.inlay_hints{
 autocmd InsertLeave,BufEnter,BufWinEnter,TabEnter,BufWritePost *.rs :lua require'lsp_extensions'.inlay_hints{ prefix = ' » ', highlight = "NonText" }
 ```
 
+## Closing Labels (dartls)
+![closing-labels](https://raw.githubusercontent.com/tjdevries/media.repo/b4a4a20d0c31a4905e42e219cf854c9aa104edbd/lsp_extensions/dart-closingLabels.png)
+
+[Closing Labels Documentation](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md#darttextdocumentpublishclosinglabels-notification)
+
+Check out the [example file](examples/dart/closing_labels.lua) for setup
+
 ## Clips
 
 - Showing Line Diagnostics: https://clips.twitch.tv/ProductiveBoxyPastaCoolStoryBro
@@ -63,5 +70,6 @@ autocmd InsertLeave,BufEnter,BufWinEnter,TabEnter,BufWritePost *.rs :lua require
 - This Plugin:
 
   - Lined up hints: https://clips.twitch.tv/DaintyCorrectMarjoramKeepo
+  - [Closing Labels Demo](https://github.com/tjdevries/media.repo/blob/b4a4a20d0c31a4905e42e219cf854c9aa104edbd/lsp_extensions/dart-closingLabels.mp4)
 
 - N E O V I M: https://clips.twitch.tv/SmoothGoodTurnipCmonBruh

--- a/examples/dart/closing_labels.lua
+++ b/examples/dart/closing_labels.lua
@@ -1,0 +1,9 @@
+-- The configured callback will fetch the labels automatically. You just need
+-- to tell the labels to be drawn.
+vim.cmd [[autocmd DartShowClosingLabels CursorHold,CursorHoldI *.dart :lua require('lsp_extensions.dart.closing_labels').draw_labels()]]
+
+-- With a group
+vim.cmd [[augroup DartShowClosingLabels]]
+vim.cmd [[  au!]]
+vim.cmd [[  autocmd CursorHold,CursorHoldI *.dart :lua require('lsp_extensions.dart.closing_labels').draw_labels()]]
+vim.cmd [[augroup END]]

--- a/examples/dart/closing_labels.lua
+++ b/examples/dart/closing_labels.lua
@@ -1,9 +1,12 @@
--- The configured callback will fetch the labels automatically. You just need
--- to tell the labels to be drawn.
-vim.cmd [[autocmd DartShowClosingLabels CursorHold,CursorHoldI *.dart :lua require('lsp_extensions.dart.closing_labels').draw_labels()]]
+local nvim_lsp = require('nvim_lsp')
 
--- With a group
-vim.cmd [[augroup DartShowClosingLabels]]
-vim.cmd [[  au!]]
-vim.cmd [[  autocmd CursorHold,CursorHoldI *.dart :lua require('lsp_extensions.dart.closing_labels').draw_labels()]]
-vim.cmd [[augroup END]]
+nvim_lsp.dartls.setup{
+  init_options = {
+    closingLabels = true,
+  },
+  callbacks = {
+    -- get_callback can be called with or without arguments
+    ['dart/textDocument/publishClosingLabels'] = require('lsp_extensions.dart.closing_labels').get_callback({highlight = "Special", prefix = " >> "}),
+  },
+}
+

--- a/lua/lsp_extensions/dart/closing_labels.lua
+++ b/lua/lsp_extensions/dart/closing_labels.lua
@@ -33,8 +33,9 @@ M.get_callback = function(opts)
 
   local get_draw_labels = function(opts)
     return function()
-      local highlight = opts.highlight
-      local prefix = opts.prefix
+      opts = opts or {}
+      local highlight = opts.highlight or "Comment"
+      local prefix = opts.prefix or "// "
       local bufnr = 0
       local uri = vim.uri_from_bufnr(bufnr)
       local labels = all_labels[uri] or {}

--- a/lua/lsp_extensions/dart/closing_labels.lua
+++ b/lua/lsp_extensions/dart/closing_labels.lua
@@ -31,11 +31,6 @@ local closing_labels_ns = vim.api.nvim_create_namespace('lsp_extensions.dart.clo
 -- @tparam table a table of options: highlight, prefix
 M.get_callback = function(opts)
 
-  vim.cmd [[augroup DartShowClosingLabels]]
-  vim.cmd [[  au!]]
-  vim.cmd [[  autocmd CursorHold,CursorHoldI *.dart :lua require('lsp_extensions.dart.closing_labels').draw_labels()]]
-  vim.cmd [[augroup END]]
-
   local get_draw_labels = function(opts)
     return function()
       local highlight = opts.highlight
@@ -49,7 +44,6 @@ M.get_callback = function(opts)
         local text = prefix .. label.label
         vim.api.nvim_buf_set_virtual_text(bufnr, closing_labels_ns, end_line, { { text, highlight } }, {})
       end
-
 
       vim.api.nvim_buf_clear_namespace(bufnr, closing_labels_ns, 0, -1)
       for _, label in pairs(labels) do

--- a/lua/lsp_extensions/dart/closing_labels.lua
+++ b/lua/lsp_extensions/dart/closing_labels.lua
@@ -17,51 +17,38 @@ nvim_lsp.dartls.setup{
   },
 }
 ```
-
 https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md#darttextdocumentpublishclosinglabels-notification
 --]]
-
 local M = {}
--- Stored labels from the server's notifications keyed by uri
-local all_labels = {}
+
 -- Namespace for the virtual text
 local closing_labels_ns = vim.api.nvim_create_namespace('lsp_extensions.dart.closing_labels')
+
+-- Draws the newly published labels in the current buffer
+-- @tparam table a table of options: highlight, prefix
+-- @tparam table a table of labels for the current buffer
+local draw_labels = function(opts, labels)
+  opts = opts or {}
+  local highlight = opts.highlight or "Comment"
+  local prefix = opts.prefix or "// "
+  vim.api.nvim_buf_clear_namespace(0, closing_labels_ns, 0, -1)
+  for _, label in pairs(labels) do
+    local end_line = label.range["end"].line
+    local text = prefix .. label.label
+    vim.api.nvim_buf_set_virtual_text(0, closing_labels_ns, end_line, { { text, highlight } }, {})
+  end
+end
 
 -- Gets a callback to register to the dartls publishClosingLabels notification.
 -- @tparam table a table of options: highlight, prefix
 M.get_callback = function(opts)
-
-  local get_draw_labels = function(opts)
-    return function()
-      opts = opts or {}
-      local highlight = opts.highlight or "Comment"
-      local prefix = opts.prefix or "// "
-      local bufnr = 0
-      local uri = vim.uri_from_bufnr(bufnr)
-      local labels = all_labels[uri] or {}
-
-      local display_virt_text = function(label)
-        local end_line = label.range["end"].line
-        local text = prefix .. label.label
-        vim.api.nvim_buf_set_virtual_text(bufnr, closing_labels_ns, end_line, { { text, highlight } }, {})
-      end
-
-      vim.api.nvim_buf_clear_namespace(bufnr, closing_labels_ns, 0, -1)
-      for _, label in pairs(labels) do
-        display_virt_text(label)
-      end
-    end
-  end
-
-  -- Draws closing labels in the current buffer
-  M.draw_labels = get_draw_labels(opts)
-
   return function(_, _, result, _, _)
     local uri = result.uri
     local labels = result.labels
-    all_labels[uri] = labels
+    -- This check is meant to prevent stray events from over-writing labels that
+    -- don't match the current buffer.
     if uri == vim.uri_from_bufnr(0) then
-      M.draw_labels()
+      draw_labels(opts, labels)
     end
   end
 end

--- a/lua/lsp_extensions/dart/closing_labels.lua
+++ b/lua/lsp_extensions/dart/closing_labels.lua
@@ -1,0 +1,76 @@
+--[[
+## Closing Labels
+
+** Method: 'dart/textDocument/publishClosingLabels**
+Direction: Server -> Client Params: { uri: string, labels: { label: string, range: Range }[] }
+This notifies the client when closing label information is available (or updated) for a file.
+
+Since this is a notification, the callback needs to be registered in the client's callbacks table.
+This can be achieved with nvim_lspconfig with this minimal config.
+```lua
+nvim_lsp.dartls.setup{
+  init_options = {
+    closingLabels = true,
+  },
+  callbacks = {
+    ['dart/textDocument/publishClosingLabels'] = require('lsp_extensions.dart.closing_labels').get_callback{},
+  },
+}
+```
+
+https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md#darttextdocumentpublishclosinglabels-notification
+--]]
+
+local M = {}
+-- Stored labels from the server's notifications keyed by uri
+local all_labels = {}
+-- Namespace for the virtual text
+local closing_labels_ns = vim.api.nvim_create_namespace('lsp_extensions.dart.closing_labels')
+-- Stored opts from the get_callback invocation.
+local label_opts = {}
+
+-- Gets a callback to register to the dartls publishClosingLabels notification.
+-- @tparam table a table of options: highlight, prefix
+M.get_callback = function(opts)
+  label_opts.highlight = opts.highlight or "Comment"
+  label_opts.prefix = opts.prefix or " // "
+
+  vim.cmd [[augroup DartShowClosingLabels]]
+  vim.cmd [[  au!]]
+  vim.cmd [[  autocmd CursorHold,CursorHoldI *.dart :lua require('lsp_extensions.dart.closing_labels').draw_labels()]]
+  vim.cmd [[augroup END]]
+
+  return function(_, _, result, _, _)
+    local uri = result.uri
+    local labels = result.labels
+    all_labels[uri] = labels
+    if uri == vim.uri_from_bufnr(0) then
+      M.draw_labels()
+    end
+  end
+end
+
+-- Draws closing labels in the current buffer
+M.draw_labels = function()
+  local opts = label_opts
+
+  local highlight = opts.highlight
+  local prefix = opts.prefix
+  local bufnr = 0
+  local uri = vim.uri_from_bufnr(bufnr)
+  local labels = all_labels[uri] or {}
+
+  local display_virt_text = function(label)
+    local end_line = label.range["end"].line
+    local text = prefix .. label.label
+    vim.api.nvim_buf_set_virtual_text(bufnr, closing_labels_ns, end_line, { { text, highlight } }, {})
+  end
+
+
+  vim.api.nvim_buf_clear_namespace(bufnr, closing_labels_ns, 0, -1)
+  for _, label in pairs(labels) do
+    display_virt_text(label)
+  end
+end
+
+return M


### PR DESCRIPTION
Hey TJ, thanks for the help on stream today. Here is the handler I came up with for the dart closing labels support. I decided to put it in a dart subfolder because dart has a handful of extensions but maybe you'd prefer to keep the file structure flat :shrug: 

The way this notification works is it seems to publish an event for every file that has closing labels on every edit. I couldn't seem to just get labels for the current buffer. I'm happy to include screenshots or a video demo if that would be helpful as well.

Thanks for reviewing when you have time :smile: 