### PR TITLE
Don't display parameter name hints

### DIFF
--- a/lua/lsp_extensions/inlay_hints.lua
+++ b/lua/lsp_extensions/inlay_hints.lua
@@ -64,7 +64,7 @@ inlay_hints.get_callback = function(opts)
 
     for _, hint in ipairs(result) do
       local finish = hint.range["end"].line
-      if not hint_store[finish] or hint.kind == "ChainingHint" then
+      if (not hint_store[finish] or hint.kind == "ChainingHint") and (hint.kind ~= "ParameterHint") then
         hint_store[finish] = hint
 
         if aligned then


### PR DESCRIPTION
I don't think it makes much sense to display parameter name hints at the end of the line because
1. they interfere with type hints (I find it confusing to have type and parameter name hints mixed together),
2. they're far away from the parameter value and
3. most of the time they're not that helpful as only the name of the first parameter of the line is displayed.

If you don't agree with my point of view I'd love an extra parameter for `inlay_hints` to disable parameter name hints. I fear I'm not versed enough in Lua and nvim scripting to implement this myself.