### PR TITLE
Dart outline fzf and telescope handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,16 @@ autocmd InsertLeave,BufEnter,BufWinEnter,TabEnter,BufWritePost *.rs :lua require
 Check out the [example file](examples/dart/closing_labels.lua) for setup
 
 ## Outline (dartls)
-![outline](https://raw.githubusercontent.com/tjdevries/media.repo/b27a8366b460cac2629d5fdb81862e5bd1d0a553/lsp_extensions/dart-outline.png)
+Rending in loclist:
+<img align="left" alt="dart-outline-loclist" src="https://raw.githubusercontent.com/tjdevries/media.repo/b27a8366b460cac2629d5fdb81862e5bd1d0a553/lsp_extensions/dart-outline.png">
+
+
+Rendering in fzf:
+<img align="left" alt="dart-outline-fzf" src="https://raw.githubusercontent.com/PatOConnor43/media.repo/0a8aa1c6fc89087c4771557c1e59864700821b26/lsp_extensions/dart-outline-fzf.png">
+
+
+Rendering in telescope:
+<img align="left" alt="dart-outline-telescope" src="https://raw.githubusercontent.com/PatOConnor43/media.repo/0a8aa1c6fc89087c4771557c1e59864700821b26/lsp_extensions/dart-outline-telescope.png">
 
 [Outline Documentation](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md#darttextdocumentpublishoutline-notification)
 

--- a/examples/dart/outline.lua
+++ b/examples/dart/outline.lua
@@ -12,7 +12,7 @@ nvim_lsp.dartls.setup{
 }
 
 -- Next, when you want to actually show the outline, you will need to call one
--- of the display methods (either loclist() or custom().
+-- of the display methods.
 require('lsp_extensions.dart.outline').loclist({})
 
 -- If you want to handle the display yourself you can use the `custom()` function.
@@ -23,8 +23,7 @@ require('lsp_extensions.dart.outline').custom({}, function(items) print(items) e
 -- prefixes you can do that by passing `kind_prefixes` into the opts. If you
 -- pair this with a patched [Nerdfont](https://www.nerdfonts.com/) you can
 -- define a very custom experience. You can define a function that looks like:
-DART_SHOW_OUTLINE = function()
-    require('lsp_extensions.dart.outline').loclist({kind_prefixes={
+DART_KIND_PREFIXES = {
         CLASS = "",
         CLASS_TYPE_ALIAS = "",
         COMPILATION_UNIT = "ﴒ",
@@ -52,8 +51,14 @@ DART_SHOW_OUTLINE = function()
         UNIT_TEST_GROUP = "﬽",
         UNIT_TEST_TEST = "",
         UNKNOWN = "",
-    }})
+    }
+DART_SHOW_OUTLINE = function()
+    require('lsp_extensions.dart.outline').loclist({kind_prefixes=DART_KIND_PREFIXES})
 end
 
 -- And then call it from neovim with :lua DART_SHOW_OUTLINE()
 
+-- The outline also has built in handlers for fzf and telescope.nvim
+require('lsp_extensions.dart.outline').fzf({kind_prefixes=DART_KIND_PREFIXES, fzf_opts={'--height', '40%', '--reverse', '--border', '--inline-info'}})
+-- OR
+require('lsp_extensions.dart.outline').telescope({kind_prefixes=DART_KIND_PREFIXES, telescope_opts={borderchars={'▃', '▐', '▀', '▍', '▃', '▃', '▀', '▀'}}})

--- a/lua/lsp_extensions/dart/outline.lua
+++ b/lua/lsp_extensions/dart/outline.lua
@@ -256,12 +256,16 @@ M.telescope = function(opts)
         previewer = previewers.qflist.new(telescope_opts),
         sorter = sorters.get_generic_fuzzy_sorter(telescope_opts),
         attach_mappings = function(prompt_bufnr, map)
-          local run_command = function()
-            local selection = actions.get_selected_entry(prompt_bufnr)
+          local run_command = function(bufnr)
+            local selection = actions.get_selected_entry(bufnr)
             actions.close(prompt_bufnr)
             vim.call('cursor', selection.lnum, selection.col+1)
           end
 
+          map('i', '<C-k>', actions.move_selection_previous)
+          map('i', '<C-j>', actions.move_selection_next)
+          map('n', '<C-k>', actions.move_selection_previous)
+          map('n', '<C-j>', actions.move_selection_next)
           map('i', '<CR>', run_command)
           map('n', '<CR>', run_command)
 

--- a/lua/lsp_extensions/dart/outline.lua
+++ b/lua/lsp_extensions/dart/outline.lua
@@ -146,7 +146,7 @@ end
 --
 -- @tparam table opts is table used to mutate items
 -- @tparam table outline the outline for the current request
--- @treturn table {{filename = string, lnum = number, col = number, text = string}, ...}
+-- @treturn table {{filename = string, lnum = number, col = number, text = string, tree_prefix = string}, ...}
 local build_items = function(opts, outline)
   local fname = vim.api.nvim_buf_get_name(0)
   local items = {}
@@ -159,9 +159,9 @@ end
 -- This function allows you to specify your own outline handler to do whatever
 -- you want. Check out the loclist implementation as an example.
 --
--- @tparam table opts is table used to mutate items. opts.kind_prefixes is a
--- table that allows specifying a prefix per kind type. This can be especially
--- useful if you want to display unicode or patched font icons.
+-- @tparam table opts is table used to mutate items.
+--   - opts.kind_prefixes is a table that allows specifying a prefix per kind type.
+--     This can be especially useful if you want to display unicode or patched font icons.
 -- @tparam function(items) handler is a function which takes a list of items
 M.custom = function(opts, handler)
   opts = opts or {}
@@ -177,9 +177,9 @@ end
 
 -- This function displays the outline in the loclist.
 --
--- @tparam table opts is table used to mutate items. opts.kind_prefixes is a
--- table that allows specifying a prefix per kind type. This can be especially
--- useful if you want to display unicode or patched font icons.
+-- @tparam table opts is table used to mutate items.
+--   - opts.kind_prefixes is a table that allows specifying a prefix per kind type.
+--     This can be especially useful if you want to display unicode or patched font icons.
 M.loclist = function(opts)
   M.custom(opts, function(items)
     vim.fn.setloclist(0, {}, ' ', {
@@ -190,6 +190,13 @@ M.loclist = function(opts)
   end)
 end
 
+-- This function displays the outline in fzf.
+--
+-- @tparam table opts is table used to mutate items.
+--   - opts.tree is a bool specifying if you want the outline to appear as a tree.
+--   - opts.kind_prefixes is a table that allows specifying a prefix per kind type.
+--     This can be especially useful if you want to display unicode or patched font icons.
+--   - opts.fzf_opts is a table of strings passed to fzf. Default: {'--reverse'}
 M.fzf = function(opts)
    M.custom(opts, function(items)
      opts = opts or {}
@@ -219,6 +226,14 @@ M.fzf = function(opts)
    end)
 end
 
+-- This function displays the outline with telescope.nvim.
+--
+-- @tparam table opts is table used to mutate items.
+--   - opts.tree is a bool specifying if you want the outline to appear as a tree.
+--   - opts.kind_prefixes is a table that allows specifying a prefix per kind type.
+--     This can be especially useful if you want to display unicode or patched font icons.
+--   - opts.telescope_opts is a table of options passed to telescope. Default:
+--     {hide_filename = true, ignore_filename = true, sorting_strategy = 'ascending'}
 M.telescope = function(opts)
   M.custom(opts, function(items)
     local has_telescope, pickers = pcall(require, 'telescope.pickers')

--- a/lua/lsp_extensions/dart/outline.lua
+++ b/lua/lsp_extensions/dart/outline.lua
@@ -193,10 +193,13 @@ end
 M.fzf = function(opts)
    M.custom(opts, function(items)
      opts = opts or {}
+     if opts.tree == nil then
+       opts.tree = true
+     end
      local fzf_opts = opts.fzf_opts or {'--reverse'}
      local stringifiedItems = {}
      for _, item in ipairs(items) do
-         table.insert(stringifiedItems, string.format('%s%s:%d:%d',item.tree_prefix, item.text, item.lnum, item.col))
+         table.insert(stringifiedItems, string.format('%s%s:%d:%d', (opts.tree and item.tree_prefix) or '', item.text, item.lnum, item.col))
      end
      -- Calling fzf as explained here:
      -- https://github.com/junegunn/fzf/issues/1778#issuecomment-697208274


### PR DESCRIPTION
## Description
I implemented 2 new handlers for the dart outline, fzf and telescope. They both support passing along options to their respective handler. `opts.fzf_opts` and `opts.telescope_opts`. Additionally, I added a `tree_prefix` to the built items to simulate a really simple tree structure indentation.

## Setup
The new handlers can be called with:
```lua
require('lsp_extensions.dart.outline').fzf()
```
and
```lua
require('lsp_extensions.dart.outline').telescope()
```
The example file documents more complex usage.

## Implementation
Both handlers support navigating directly to the selected element. FZF does this by including line and column numbers in the selected line. The line is parsed to retrieve these values and then `cursor` is called with the parsed values. Telescope passes the whole `entry` on selection so line parsing can be avoided.