### PR TITLE
Remove stray mapping

### DIFF
--- a/plugin/lsp_extensions.vim
+++ b/plugin/lsp_extensions.vim
@@ -1,1 +1,0 @@
-nnoremap ,asdf :lua require('plenary.reload').reload_module('lsp_extensions'); require('lsp_extensions').test()<CR>


### PR DESCRIPTION
An issue was created regarding a stray mapping. I don't _think_ there's a good reason to keep this around. If we wanted to keep around an entrypoint to calling that test method a better option might be to define an EX command. I just created this PR real quick if @tjdevries @rockerBOO or @glepnir want to just merge it.