### PR TITLE
rust-analyzer: Disable drawing hints for `ParameterHint` and `TypeHint`

### DIFF
--- a/lua/lsp_extensions/inlay_hints.lua
+++ b/lua/lsp_extensions/inlay_hints.lua
@@ -64,7 +64,7 @@ inlay_hints.get_callback = function(opts)
 
     for _, hint in ipairs(result) do
       local finish = hint.range["end"].line
-      if not hint_store[finish] or hint.kind == "ChainingHint" then
+      if not hint_store[finish] and hint.kind == "ChainingHint" then
         hint_store[finish] = hint
 
         if aligned then


### PR DESCRIPTION
`ChainingHint` is the only type that makes sense to draw at the end of the line. This image demonstrates how each type should probably be represented.
![image](https://user-images.githubusercontent.com/6657525/97119737-61d01400-16cf-11eb-9d7d-1abd522abd89.png)

`TypeHint`s after variable declarations, `ParameterHint`s paired with variables passed into functions, and `ChainingHint`s at the end on lines. We'll need to slightly tweak the existing implementation to put these types in their correct place so for now I'm suggesting we only draw `ChainingHint`s to reduce confusion.