### PR TITLE
Fix Error in inlay_hints.lua table expected (#15)

### DIFF
--- a/lua/lsp_extensions/inlay_hints.lua
+++ b/lua/lsp_extensions/inlay_hints.lua
@@ -56,6 +56,13 @@ inlay_hints.get_callback = function(opts)
       return
     end
 
+    -- No errors but there were no results
+    -- Adding result == 0 to above if statement causes freeze, ENTER to continue, and defocus of prompt window
+    -- This as it triggers and blocks when entering many views and temporary bufs that trigger autocmd
+    if result == 0 then
+        return
+    end
+
     vim.api.nvim_buf_clear_namespace(bufnr, inlay_hints_ns, 0, -1)
 
     local hint_store = {}


### PR DESCRIPTION
This PR fixes the issue describes in issue 15 when result == 0.

This fix does not use the if statement with a print above as that causes a block when the text is printed to the screen with the "ENTER or type command to continue" prompt, which disrupts the user especially on temporary buffers opening from vim-fugitive etc.