### PR TITLE
Add inlay_hint, enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Plug 'nvim-lua/lsp_extensions.nvim'
 
 ## Inlay Hints (rust-analyzer)
 
-![inlay-hints](https://i.imgur.com/YsOfqOk.png)
+![Customized](https://i.imgur.com/FRRas1c.png)
 
 Inlay hints for the whole file:
 
@@ -47,13 +47,12 @@ require'lsp_extensions'.inlay_hints{
 	prefix = " > ",
 	aligned = false,
 	only_current_line = false
+	enabled = { "ChainingHint" }
 }
 ```
 
-![Customized](https://i.imgur.com/FRRas1c.png)
-
 ```vimscript
-autocmd InsertLeave,BufEnter,BufWinEnter,TabEnter,BufWritePost *.rs :lua require'lsp_extensions'.inlay_hints{ prefix = ' » ', highlight = "NonText" }
+autocmd InsertLeave,BufEnter,BufWinEnter,TabEnter,BufWritePost *.rs :lua require'lsp_extensions'.inlay_hints{ prefix = ' » ', highlight = "NonText", enabled = {"ChainingHint"} }
 ```
 
 ## Closing Labels (dartls)

--- a/lua/lsp_extensions/inlay_hints.lua
+++ b/lua/lsp_extensions/inlay_hints.lua
@@ -25,14 +25,15 @@ interface InlayHint {
     label: string,
 }
 ```
---]]
+--]] 
 
 local inlay_hints = {}
 
-local inlay_hints_ns = vim.api.nvim_create_namespace('lsp_extensions.inlay_hints')
+local inlay_hints_ns = vim.api.nvim_create_namespace("lsp_extensions.inlay_hints")
 
 inlay_hints.request = function(opts, bufnr)
-  vim.lsp.buf_request(bufnr or 0, 'rust-analyzer/inlayHints', inlay_hints.get_params(), inlay_hints.get_callback(opts))
+  vim.lsp.buf_request(bufnr or 0, "rust-analyzer/inlayHints", inlay_hints.get_params(),
+                      inlay_hints.get_callback(opts))
 
   -- TODO: At some point, rust probably adds this?
   -- vim.lsp.buf_request(bufnr or 0, 'experimental/inlayHints', inlay_hints.get_params(), inlay_hints.get_callback(opts))
@@ -45,10 +46,10 @@ inlay_hints.get_callback = function(opts)
   local prefix = opts.prefix or " > "
   local aligned = opts.aligned or false
 
+  local enabled = opts.enabled or {"ChainingHint"}
+
   local only_current_line = opts.only_current_line
-  if only_current_line == nil then
-    only_current_line = false
-  end
+  if only_current_line == nil then only_current_line = false end
 
   return function(err, _, result, _, bufnr)
     -- I'm pretty sure this only happens for unsupported items.
@@ -66,13 +67,26 @@ inlay_hints.get_callback = function(opts)
 
     local longest_line = -1
 
+    -- Check if something is in the list
+    -- in_list({"ChainingHint"})("ChainingHint")
+    local in_list = function(list)
+      return function(item)
+        for _, f in ipairs(list) do
+          if f == item then return true end
+        end
+
+        return false
+      end
+    end
+
     for _, hint in ipairs(result) do
       local finish = hint.range["end"].line
-      if not hint_store[finish] or hint.kind == "ChainingHint" then
+      if not hint_store[finish] and in_list(enabled)(hint.kind) then
         hint_store[finish] = hint
 
         if aligned then
-          longest_line = math.max(longest_line, #vim.api.nvim_buf_get_lines(bufnr, finish, finish + 1, false)[1])
+          longest_line = math.max(longest_line,
+                                  #vim.api.nvim_buf_get_lines(bufnr, finish, finish + 1, false)[1])
         end
       end
     end
@@ -82,10 +96,9 @@ inlay_hints.get_callback = function(opts)
 
       -- Check for any existing / more important virtual text on the line.
       -- TODO: Figure out how stackable virtual text works? What happens if there is more than one??
-      local existing_virt_text = vim.api.nvim_buf_get_extmarks(bufnr, inlay_hints_ns, {end_line, 0}, {end_line, 0}, {})
-      if not vim.tbl_isempty(existing_virt_text) then
-        return
-      end
+      local existing_virt_text = vim.api.nvim_buf_get_extmarks(bufnr, inlay_hints_ns, {end_line, 0},
+                                                               {end_line, 0}, {})
+      if not vim.tbl_isempty(existing_virt_text) then return end
 
       local text
       if aligned then
@@ -94,7 +107,7 @@ inlay_hints.get_callback = function(opts)
       else
         text = prefix .. hint.label
       end
-      vim.api.nvim_buf_set_virtual_text(bufnr, inlay_hints_ns, end_line, { { text, highlight } }, {})
+      vim.api.nvim_buf_set_virtual_text(bufnr, inlay_hints_ns, end_line, {{text, highlight}}, {})
     end
 
     if only_current_line then
@@ -106,22 +119,17 @@ inlay_hints.get_callback = function(opts)
         display_virt_text(hint)
       end
     else
-      for _, hint in pairs(hint_store) do
-        display_virt_text(hint)
-      end
+      for _, hint in pairs(hint_store) do display_virt_text(hint) end
     end
   end
 end
 
 inlay_hints.get_params = function()
-  return {
-    textDocument = vim.lsp.util.make_text_document_params()
-  }
+  return {textDocument = vim.lsp.util.make_text_document_params()}
 end
 
 inlay_hints.clear = function()
   vim.api.nvim_buf_clear_namespace(0, inlay_hints_ns, 0, -1)
 end
-
 
 return inlay_hints


### PR DESCRIPTION
This adds `enabled` to the options for inlay hints. `ChainingHint` will be only default hint. 

```lua
require'lsp_extensions'.inlay_hints{ enabled = {"ChainingHint", "TypeHint", "ParameterHint"} } 
```

```lua
require'lsp_extensions'.inlay_hints{} -- defaults to { enabled = { 'Chaininghint' } }
```