### PR TITLE
Reorganizing for additional rust-analyzer extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ autocmd BufEnter,BufWinEnter,TabEnter *.rs :lua require'lsp_extensions'.inlay_hi
 On cursor hover, get hints for current line:
 
 ```vimscript
-autocmd CursorHold,CursorHoldI *.rs :lua require'lsp_extensions'.inlay_hints{ only_current_line = true }
+autocmd CursorHold,CursorHoldI *.rs :lua require'lsp_extensions.rust_analyzer'.inlay_hints{ only_current_line = true }
 ```
 
 Available Options (Showing defaults):

--- a/lua/lsp_extensions/init.lua
+++ b/lua/lsp_extensions/init.lua
@@ -18,10 +18,10 @@ Each extension should probably look like:
 
 local vim = vim
 local extensions = {}
-local inlay_hints = require('lsp_extensions.inlay_hints')
+local rust_analyzer = require('lsp_extensions.rust_analyzer')
 
-extensions.inlay_hints = function(opts)
-  vim.lsp.buf_request(0, 'rust-analyzer/inlayHints', inlay_hints.get_params(), inlay_hints.get_callback(opts))
-end
+extensions.rust_analyzer = {}
+extensions.rust_analyzer.inlay_hints = rust_analyzer.inlay_hints
+extensions.rust_analyzer.open_cargo_toml = rust_analyzer.open_cargo_toml
 
 return extensions

--- a/lua/lsp_extensions/rust_analyzer.lua
+++ b/lua/lsp_extensions/rust_analyzer.lua
@@ -1,0 +1,4 @@
+return {
+    inlay_hints = require('lsp_extensions/rust_analyzer/inlay_hints'),
+    open_cargo_toml = require('lsp_extensions/rust_analyzer/open_cargo_toml')
+}

--- a/lua/lsp_extensions/rust_analyzer/inlay_hints.lua
+++ b/lua/lsp_extensions/rust_analyzer/inlay_hints.lua
@@ -29,7 +29,7 @@ interface InlayHint {
 
 local inlay_hints = {}
 
-local inlay_hints_ns = vim.api.nvim_create_namespace("lsp_extensions.inlay_hints")
+local inlay_hints_ns = vim.api.nvim_create_namespace("lsp_extensions.rust_analyzer.inlay_hints")
 
 inlay_hints.request = function(opts, bufnr)
   vim.lsp.buf_request(bufnr or 0, "rust-analyzer/inlayHints", inlay_hints.get_params(),
@@ -132,4 +132,4 @@ inlay_hints.clear = function()
   vim.api.nvim_buf_clear_namespace(0, inlay_hints_ns, 0, -1)
 end
 
-return inlay_hints
+return inlay_hints.request

--- a/lua/lsp_extensions/rust_analyzer/open_cargo_toml.lua
+++ b/lua/lsp_extensions/rust_analyzer/open_cargo_toml.lua
@@ -1,0 +1,36 @@
+--[[
+Open Cargo.toml
+
+https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#open-cargotoml
+
+This request is sent from client to server to open the current project's Cargo.toml
+
+Method: experimental/openCargoToml
+
+Request: OpenCargoTomlParams
+
+Response: Location | null
+
+experimental/openCargoToml returns a single Link to the start of the [package] keyword.
+--]]
+
+local get_callback = function() 
+    return function(err, _, result, _, _) 
+        if not result or vim.tbl_isempty(result) then
+            return
+        end
+    vim.lsp.util.jump_to_location(result)
+    end 
+end
+
+local get_params = function() 
+  return {
+      textDocument = vim.lsp.util.make_text_document_params()
+  }
+end
+
+return function()
+  vim.lsp.buf_request(0, "experimental/openCargoToml", get_params(),
+                      get_callback())
+end
+


### PR DESCRIPTION
I should start by saying I'm very new to neovim and lua, but I'm trying to adopt it as my main editor for Rust dev. The extra rust-analyzer extensions are crucial for this, in my opinion. There are some very useful commands, like "expand macro" and "open cargo.toml"

In this PR, I implemented the open cargo file command and also reorganized the structure of the project to prepare for more rust-analzyer specific extensions. By moving the inlay-hints ext to the `rust-analyzer` module, it will break current configurations, but I think it's better for organization.

If this does get merged, I will gladly update the documentation with how to use the "open cargo file" function:
```
:lua require('lsp_extensions.rust_analyzer').open_cargo_toml()
```
...and any others that will be added

Please nitpick or correct on anything that I did wrong or out of convention 😊 