### PR TITLE
Fix syntax error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ require'lsp_extensions'.inlay_hints{
 	highlight = "Comment",
 	prefix = " > ",
 	aligned = false,
-	only_current_line = false
+	only_current_line = false,
 	enabled = { "ChainingHint" }
 }
 ```


### PR DESCRIPTION
One of the examples missed a trailing comma. The syntax error would result in
the error:

```
E5112: Error while creating lua chunk: init.lua:6: '}' expected (to close '{' at line 1) near 'enabled'
```